### PR TITLE
solana: fix stack access violation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/example-liquidity-layer"]
     path = lib/example-liquidity-layer
     url = https://github.com/wormhole-foundation/example-liquidity-layer.git
-	branch = v0.3.2
+	branch = v0.3.3

--- a/e2e/tests/helpers/utils.ts
+++ b/e2e/tests/helpers/utils.ts
@@ -189,18 +189,18 @@ export async function completeSwapForTest(
         },
     );
 
-    let ix;
+    let swapIxes;
     if (opts.redeemMode === "direct") {
-        ix = await swapLayer.completeSwapDirectIx(accounts, { cpiInstruction });
+        swapIxes = await swapLayer.completeSwapDirectIxes(accounts, { cpiInstruction });
     } else if (opts.redeemMode === "relay") {
-        ix = await swapLayer.completeSwapRelayIx(accounts, { cpiInstruction });
+        swapIxes = await swapLayer.completeSwapRelayIxes(accounts, { cpiInstruction });
     }
 
     const ixs = [
         ComputeBudgetProgram.setComputeUnitLimit({
             units: 700_000,
         }),
-        ix,
+        ...swapIxes,
     ];
 
     const addressLookupTableAccounts = await Promise.all(
@@ -239,7 +239,7 @@ export async function swapExactInForTest(
     let { additionalLuts, signers } = opts;
     additionalLuts ??= [];
 
-    const ix = await swapLayer.initiateSwapExactInIx(accounts, args);
+    const swapIxes = await swapLayer.initiateSwapExactInIxes(accounts, args);
 
     const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
         units: 700_000,
@@ -252,7 +252,7 @@ export async function swapExactInForTest(
         }),
     );
 
-    await expectIxOk(swapLayer.connection(), [computeIx, ix], signers, {
+    await expectIxOk(swapLayer.connection(), [computeIx, ...swapIxes], signers, {
         addressLookupTableAccounts,
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4421,6 +4421,7 @@
       "version": "0.0.1",
       "resolved": "file:lib/example-liquidity-layer/wormhole-foundation-example-liquidity-layer-definitions-0.0.1.tgz",
       "integrity": "sha512-hGwQm8a1YfbvcqJOubvzduzYfl59GkTkI9dKaeI0YdqPoExFHghSmzkghzJvwAhOyT0hjGa+37ayDRygXipoSA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "^0.10.9",
         "@wormhole-foundation/sdk-definitions": "^0.10.9"
@@ -4448,6 +4449,7 @@
       "version": "0.0.1",
       "resolved": "file:lib/example-liquidity-layer/wormhole-foundation-example-liquidity-layer-evm-0.0.1.tgz",
       "integrity": "sha512-fc6k10EFHZ1OQa5Qw3lkLZAuRXHqZeAy3s+xcJ2krJmLlXiqd7pAkkm9F0Io3E9i6mTxab+YehwdqUHZoSZ91A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/example-liquidity-layer-definitions": "0.0.1",
         "@wormhole-foundation/sdk-base": "^0.10.9",

--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -34,6 +34,8 @@ url = "https://api.mainnet-beta.solana.com"
 ### every 400 ms. A fast voting cadence ensures faster finality and convergence
 ticks_per_slot = 16
 
+deactivate_feature = ["EenyoWx9UMXYKpR8mW5Jmfmy2fRjzUtM7NduYMY8bx33"]
+
 ### Wormhole Core Bridge Program
 [[test.genesis]]
 address = "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"

--- a/solana/programs/swap-layer/src/composite/mod.rs
+++ b/solana/programs/swap-layer/src/composite/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use anchor_lang::{prelude::*, system_program};
-use anchor_spl::{associated_token, token, token_interface};
+use anchor_spl::{token, token_interface};
 use common::{
     admin::utils::{
         assistant::{self, only_authorized},
@@ -328,9 +328,10 @@ pub struct CompleteSwap<'info> {
 
     /// Temporary swap token account to receive USDC from the prepared fill. This account will be
     /// closed at the end of this instruction.
+    ///
+    /// NOTE: This ATA must already be created.
     #[account(
-        init_if_needed,
-        payer = payer,
+        mut,
         associated_token::mint = usdc,
         associated_token::authority = authority,
         associated_token::token_program = token_program
@@ -339,9 +340,10 @@ pub struct CompleteSwap<'info> {
 
     /// Temporary swap token account to receive destination mint after the swap. This account will
     /// be closed at the end of this instruction.
+    ///
+    /// NOTE: This ATA must already be created.
     #[account(
-        init_if_needed,
-        payer = payer,
+        mut,
         associated_token::mint = dst_mint,
         associated_token::authority = authority,
         associated_token::token_program = dst_token_program
@@ -365,7 +367,6 @@ pub struct CompleteSwap<'info> {
 
     pub token_program: Program<'info, token::Token>,
     pub dst_token_program: Interface<'info, token_interface::TokenInterface>,
-    associated_token_program: Program<'info, associated_token::AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/solana/programs/swap-layer/src/processor/complete/swap/payload.rs
+++ b/solana/programs/swap-layer/src/processor/complete/swap/payload.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{StagedInbound, StagedInboundInfo, StagedInboundSeeds},
 };
 use anchor_lang::prelude::*;
-use anchor_spl::{associated_token, token, token_interface};
+use anchor_spl::{token, token_interface};
 use swap_layer_messages::{
     messages::SwapMessageV1,
     types::{OutputToken, RedeemMode},
@@ -35,9 +35,10 @@ pub struct CompleteSwapPayload<'info> {
 
     /// Temporary swap token account to receive USDC from the prepared fill. This account will be
     /// closed at the end of this instruction.
+    ///
+    /// NOTE: This ATA must already be created.
     #[account(
-        init_if_needed,
-        payer = payer,
+        mut,
         associated_token::mint = usdc,
         associated_token::authority = staged_inbound,
         associated_token::token_program = token_program
@@ -46,9 +47,10 @@ pub struct CompleteSwapPayload<'info> {
 
     /// Temporary swap token account to receive destination mint after the swap. This account will
     /// be closed at the end of this instruction.
+    ///
+    /// NOTE: This ATA must already be created.
     #[account(
-        init_if_needed,
-        payer = payer,
+        mut,
         associated_token::mint = dst_mint,
         associated_token::authority = staged_inbound,
         associated_token::token_program = dst_token_program
@@ -72,7 +74,6 @@ pub struct CompleteSwapPayload<'info> {
 
     token_program: Program<'info, token::Token>,
     dst_token_program: Interface<'info, token_interface::TokenInterface>,
-    associated_token_program: Program<'info, associated_token::AssociatedToken>,
     system_program: Program<'info, System>,
 }
 

--- a/solana/programs/swap-layer/src/processor/initiate/swap/exact_in.rs
+++ b/solana/programs/swap-layer/src/processor/initiate/swap/exact_in.rs
@@ -5,7 +5,7 @@ use crate::{
     PREPARED_ORDER_SEED_PREFIX,
 };
 use anchor_lang::prelude::*;
-use anchor_spl::{associated_token, token, token_interface};
+use anchor_spl::{token, token_interface};
 use common::wormhole_io::TypePrefixedPayload;
 
 #[derive(Accounts)]
@@ -89,9 +89,10 @@ pub struct InitiateSwapExactIn<'info> {
 
     /// Temporary swap token account to receive source mint from the staged custody token. This
     /// account will be closed at the end of this instruction.
+    ///
+    /// NOTE: This ATA must already be created.
     #[account(
-        init_if_needed,
-        payer = payer,
+        mut,
         associated_token::mint = src_mint,
         associated_token::authority = swap_authority,
         associated_token::token_program = src_token_program
@@ -100,9 +101,10 @@ pub struct InitiateSwapExactIn<'info> {
 
     /// Temporary swap token account to receive destination mint after the swap. This account will
     /// be closed at the end of this instruction.
+    ///
+    /// NOTE: This ATA must already be created.
     #[account(
-        init_if_needed,
-        payer = payer,
+        mut,
         associated_token::mint = usdc,
         associated_token::authority = swap_authority
     )]
@@ -126,7 +128,6 @@ pub struct InitiateSwapExactIn<'info> {
     prepared_custody_token: UncheckedAccount<'info>,
 
     token_router_program: Program<'info, token_router::program::TokenRouter>,
-    associated_token_program: Program<'info, associated_token::AssociatedToken>,
     src_token_program: Interface<'info, token_interface::TokenInterface>,
     token_program: Program<'info, token::Token>,
     system_program: Program<'info, System>,


### PR DESCRIPTION
**This is a breaking change.**

Instead of using `init_if_needed` for swap ATAs, these ATAs are now expected to be created before invoking any of the swap instructions:
- initiate_swap_exact_in
- complete_swap_direct
- complete_swap_payload
- complete_swap_relay

Anchor's `init` (and `init_if_needed`) macro directives use a good chunk of stack memory. But the stack access errors aren't detected until runtime. To avoid this completely, we require that the create idempotent Associated Token program instruction be called for each of the swap's source and destination token accounts.

The only instruction having this issue was `complete_swap_payload`. But we made the swap ATA handling consistent among all of the instructions above.