### PR TITLE
Make Initiate Function Compatible with Mayan Forwarder

### DIFF
--- a/evm/src/ISwapLayer.sol
+++ b/evm/src/ISwapLayer.sol
@@ -11,8 +11,9 @@ import { OrderResponse } from "liquidity-layer/interfaces/ITokenRouter.sol";
 interface ISwapLayer {
   //selector: 0f3376b1
   function initiate(
-    uint16 targetChain,
     bytes32 recipient, //must be the redeemer in case of a custom payload
+    uint256 overrideAmountIn,
+    uint16 targetChain,
     bytes calldata params
   ) external payable returns (bytes memory);
 

--- a/evm/src/SwapLayerIntegrationBase.sol
+++ b/evm/src/SwapLayerIntegrationBase.sol
@@ -203,8 +203,9 @@ abstract contract SwapLayerIntegrationBase {
     try _swapLayer().initiate{
       value: _swapLayerReplaceFeePlaceholderChecked(params.msgValueOrPlaceholder)
       }(
-        params.targetParams.chainId,
         params.targetParams.recipient,
+        0,
+        params.targetParams.chainId,
         params.params
       )
     returns (bytes memory successData) { return (true,  successData); }

--- a/evm/src/assets/SwapLayerInitiate.sol
+++ b/evm/src/assets/SwapLayerInitiate.sol
@@ -274,7 +274,7 @@ abstract contract SwapLayerInitiate is SwapLayerRelayingFees {
   }
 
   function replaceAmountIn(
-    bytes calldata params,
+    bytes memory params,
     uint256 amountIn
   ) private pure returns(bytes memory) {
     require(params.length >= 40, "params too short");

--- a/evm/src/assets/SwapLayerInitiate.sol
+++ b/evm/src/assets/SwapLayerInitiate.sol
@@ -33,7 +33,7 @@ abstract contract SwapLayerInitiate is SwapLayerRelayingFees {
     uint16 targetChain,
     bytes memory inputParams
   ) external payable returns (bytes memory) { unchecked {
-    params = replaceAmountIn(inputParams, amountIn);
+    bytes memory params = replaceAmountIn(inputParams, amountIn);
     checkAddr(targetChain, recipient);
     ModesOffsetsSizes memory mos = parseParamBaseStructure(targetChain, params);
 

--- a/evm/src/assets/SwapLayerInitiate.sol
+++ b/evm/src/assets/SwapLayerInitiate.sol
@@ -31,7 +31,7 @@ abstract contract SwapLayerInitiate is SwapLayerRelayingFees {
     bytes32 recipient, //= redeemer in case of a payload
     uint256 amountIn,
     uint16 targetChain,
-    bytes memory params
+    bytes memory inputParams
   ) external payable returns (bytes memory) { unchecked {
     params = replaceAmountIn(inputParams, amountIn);
     checkAddr(targetChain, recipient);

--- a/evm/test/Initiate.t.sol
+++ b/evm/test/Initiate.t.sol
@@ -126,8 +126,9 @@ contract InitiateTest is SLTSwapBase, SwapLayerIntegrationBase {
       value: _wormholeMsgFee() + (inputToken == IoToken.Gas ? inputAmount : 0)
     }(abi.encodeWithSelector(
       swapLayer.initiate.selector,
-      FOREIGN_CHAIN_ID,
       user.toUniversalAddress(),
+      0,
+      FOREIGN_CHAIN_ID,
       abi.encodePacked(
         FastTransferMode.Disabled,
         new bytes(0),
@@ -467,8 +468,9 @@ contract InitiateTest is SLTSwapBase, SwapLayerIntegrationBase {
     (bool success, bytes memory returnData) = address(swapLayer).call{value: vars.msgValue}(
       abi.encodeCall(
         swapLayer.initiate, (
-          vars.targetChain,
           user.toUniversalAddress(),
+          0,
+          vars.targetChain,
           abi.encodePacked(
             vars.fastTransferMode,
             vars.transferParams,

--- a/evm/test/Permits.t.sol
+++ b/evm/test/Permits.t.sol
@@ -37,8 +37,9 @@ contract PermitsTest is SLTSwapBase {
     vm.startPrank(user);
     usdc.approve(address(swapLayer), amount);
     bytes memory swapReturn = swapLayer.initiate(
-      FOREIGN_CHAIN_ID,
       user.toUniversalAddress(),
+      0,
+      FOREIGN_CHAIN_ID,
       abi.encodePacked(
         false,           //fast transfer
         RedeemMode.Direct,
@@ -88,8 +89,9 @@ contract PermitsTest is SLTSwapBase {
     vm.startPrank(user);
     usdc.approve(permit2, amount);
     bytes memory swapReturn = swapLayer.initiate(
-      FOREIGN_CHAIN_ID,
       user.toUniversalAddress(),
+      0,
+      FOREIGN_CHAIN_ID,
       abi.encodePacked(
         false,           //fast transfer
         RedeemMode.Direct,
@@ -140,8 +142,9 @@ contract PermitsTest is SLTSwapBase {
     vm.startPrank(user);
     usdc.approve(permit2, amount);
     bytes memory swapReturn = swapLayer.initiate(
-      FOREIGN_CHAIN_ID,
       user.toUniversalAddress(),
+      0,
+      FOREIGN_CHAIN_ID,
       abi.encodePacked(
         false,           //fast transfer
         RedeemMode.Direct,


### PR DESCRIPTION
Re-order the initiate function of Swap Layer to make it compatible with Mayan Forwarder contract:

[MayanForwarder.sol](https://github.com/mayan-finance/swap-bridge/blob/main/src/MayanForwarder.sol)

When a source chain swap is involved, we need to replace the input amount with the output amount of the swap. The forwarder contract expects the input amount to be located at byte 36. To achieve this, we have reordered the input parameters of the initiate function and added an amountIn parameter that will replace the current amount in the parameters.
