### PR TITLE
evm: add forge scripts for deployment

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -103,4 +103,53 @@ Build the sdk:
 `cd ts-sdk && npm ci && npm run build`
 
 Then configure `.env` with your private keys before finally running the scripts via `package.json`.
- 
+
+
+## Running forge-scripts
+
+### Deployment 
+
+Before deploying the swap layer contract:
+
+1. Open `cfg/evm.deployments.json`
+2. Update the following in the configuration:
+   - Set addresses in the `deployment` array (currently `address(0)`)
+   - Configure any additional desired networks
+   - Ensure all target networks are properly configured before proceeding
+
+> **Important**: The configuration file includes example entries with testnet Wormhole chain IDs. Forge requires dictionary keys to be in alphabetical order - do not modify this ordering.
+
+To run the deployment script, run the following command from the `root`:
+```
+# Parameters:
+
+# YOUR_RPC: Network RPC endpoint
+# YOUR_PRIVATE_KEY: Deployment wallet private key
+# WORMHOLE_CHAIN_ID: Target network's Wormhole chain ID
+
+bash sh/deploy.sh -r YOUR_RPC -k YOUR_PRIVATE_KEY -c WORMHOLE_CHAIN_ID
+```
+
+Run this command for each network in the `evm.deployments.json` config. Make sure to save each address that is output in the forge logs. The [Configuration](#configuration) section relies on the `deployment` section of the config file, so please do not modify any values post deployment.
+
+### Configuration
+
+After deploying to each network, do the following:
+1. Add each 32-byte proxy address to the `registrations` section of the `evm.deployments.json` file
+2. Configure the relay parameters for each network. See the `FeeParams.sol` file for more information about these parameters
+
+> **Important**: `gasDropoffMargin` and `gasPriceMargin` are both set using `fractionalDigits` of zero. Meaning, that if you set the `gasPriceMargin` parameter to `25` in this config, that will be 25%. The ConfigureSwapLayer.s.sol file will need to be updated to use different `fractionalDigits`. 
+
+To run the configuration script, run the following command from the `root`:
+
+```
+bash sh/deploy.sh -r YOUR_RPC -k YOUR_PRIVATE_KEY -c WORMHOLE_CHAIN_ID -a configure
+```
+
+### Validation
+
+To confirm that the contract was configured according to the parameters specified in `evm.deployments.json`. Run the following command for each network:
+
+```
+bash sh/deploy.sh -r YOUR_RPC -k YOUR_PRIVATE_KEY -c WORMHOLE_CHAIN_ID -a validate
+```

--- a/evm/cfg/evm.deployment.json
+++ b/evm/cfg/evm.deployment.json
@@ -1,0 +1,29 @@
+{
+    "contracts": [
+        {
+            "chainId": 6,
+            "circleDomain": 1,
+            "wormholeAddress": "0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C",
+            "liquidityLayerAddress": "0x8Cd7D7C980cd72eBD16737dC3fa04469dcFcf07A",
+            "universalRouterAddress": "0x0000000000000000000000000000000000000000",
+            "permit2Address": "0x0000000000000000000000000000000000000000",
+            "usdcAddress": "0x5425890298aed601595a70ab815c96711a31bc65",
+            "circleMessageTransmitter": "0xa9fb1b3009dcb79e2fe346c16a604b8fa8ae0a79",
+            "wethAddress": "0xd00ae08403b9bbb9124bb305c09058e32c39a48c",
+            "traderJoeRouterAddress": "0xb4315e873dBcf96Ffd0acd8EA43f689D8c20fB30"
+        },
+        {
+            "chainId": 10003,
+            "circleDomain": 3,
+            "rpc": "https://public.stackup.sh/api/v1/node/arbitrum-sepolia",
+            "wormholeAddress": "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35",
+            "liquidityLayerAddress": "0xe0418C44F06B0b0D7D1706E01706316DBB0B210E",
+            "universalRouterAddress": "0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2",
+            "permit2Address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
+            "usdcAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+            "circleMessageTransmitter": "0xaCF1ceeF35caAc005e15888dDb8A3515C41B4872",
+            "wethAddress": "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
+            "traderJoeRouterAddress": "0x0000000000000000000000000000000000000000"
+        }
+    ]
+}

--- a/evm/cfg/evm.deployment.json
+++ b/evm/cfg/evm.deployment.json
@@ -3,27 +3,26 @@
         {
             "chainId": 6,
             "circleDomain": 1,
-            "wormholeAddress": "0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C",
-            "liquidityLayerAddress": "0x8Cd7D7C980cd72eBD16737dC3fa04469dcFcf07A",
-            "universalRouterAddress": "0x0000000000000000000000000000000000000000",
-            "permit2Address": "0x0000000000000000000000000000000000000000",
-            "usdcAddress": "0x5425890298aed601595a70ab815c96711a31bc65",
             "circleMessageTransmitter": "0xa9fb1b3009dcb79e2fe346c16a604b8fa8ae0a79",
+            "liquidityLayerAddress": "0x8Cd7D7C980cd72eBD16737dC3fa04469dcFcf07A",
+            "permit2Address": "0x0000000000000000000000000000000000000000",
+            "traderJoeRouterAddress": "0xb4315e873dBcf96Ffd0acd8EA43f689D8c20fB30",
+            "universalRouterAddress": "0x0000000000000000000000000000000000000000",
+            "usdcAddress": "0x5425890298aed601595a70ab815c96711a31bc65",
             "wethAddress": "0xd00ae08403b9bbb9124bb305c09058e32c39a48c",
-            "traderJoeRouterAddress": "0xb4315e873dBcf96Ffd0acd8EA43f689D8c20fB30"
+            "wormholeAddress": "0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C"
         },
         {
             "chainId": 10003,
             "circleDomain": 3,
-            "rpc": "https://public.stackup.sh/api/v1/node/arbitrum-sepolia",
-            "wormholeAddress": "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35",
-            "liquidityLayerAddress": "0xe0418C44F06B0b0D7D1706E01706316DBB0B210E",
-            "universalRouterAddress": "0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2",
-            "permit2Address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
-            "usdcAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
             "circleMessageTransmitter": "0xaCF1ceeF35caAc005e15888dDb8A3515C41B4872",
+            "liquidityLayerAddress": "0xe0418C44F06B0b0D7D1706E01706316DBB0B210E",
+            "permit2Address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
+            "traderJoeRouterAddress": "0x0000000000000000000000000000000000000000",
+            "universalRouterAddress": "0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2",
+            "usdcAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
             "wethAddress": "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
-            "traderJoeRouterAddress": "0x0000000000000000000000000000000000000000"
+            "wormholeAddress": "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"
         }
     ]
 }

--- a/evm/cfg/evm.deployment.json
+++ b/evm/cfg/evm.deployment.json
@@ -1,28 +1,42 @@
 {
-    "contracts": [
+    "deployment": [
         {
+            "assistant": "0x",
             "chainId": 6,
             "circleDomain": 1,
             "circleMessageTransmitter": "0xa9fb1b3009dcb79e2fe346c16a604b8fa8ae0a79",
+            "feeRecipient": "0x",
+            "feeUpdater": "0x",
             "liquidityLayerAddress": "0x8Cd7D7C980cd72eBD16737dC3fa04469dcFcf07A",
             "permit2Address": "0x0000000000000000000000000000000000000000",
             "traderJoeRouterAddress": "0xb4315e873dBcf96Ffd0acd8EA43f689D8c20fB30",
             "universalRouterAddress": "0x0000000000000000000000000000000000000000",
-            "usdcAddress": "0x5425890298aed601595a70ab815c96711a31bc65",
             "wethAddress": "0xd00ae08403b9bbb9124bb305c09058e32c39a48c",
             "wormholeAddress": "0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C"
         },
         {
+            "assistant": "0x",
             "chainId": 10003,
             "circleDomain": 3,
             "circleMessageTransmitter": "0xaCF1ceeF35caAc005e15888dDb8A3515C41B4872",
+            "feeRecipient": "0x",
+            "feeUpdater": "0x",
             "liquidityLayerAddress": "0xe0418C44F06B0b0D7D1706E01706316DBB0B210E",
             "permit2Address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
             "traderJoeRouterAddress": "0x0000000000000000000000000000000000000000",
             "universalRouterAddress": "0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2",
-            "usdcAddress": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
             "wethAddress": "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
             "wormholeAddress": "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"
+        }
+    ],
+    "registrations": [
+        {
+            "chainId": 6,
+            "address": "0x"
+        },
+        {
+            "chainId": 10003,
+            "address": "0x"
         }
     ]
 }

--- a/evm/cfg/evm.deployment.json
+++ b/evm/cfg/evm.deployment.json
@@ -1,54 +1,54 @@
 {
     "deployment": [
         {
-            "assistant": "0x",
+            "assistant": "0x0000000000000000000000000000000000000000",
             "chainId": 6,
             "circleDomain": 1,
-            "circleMessageTransmitter": "0xa9fb1b3009dcb79e2fe346c16a604b8fa8ae0a79",
-            "feeRecipient": "0x",
-            "feeUpdater": "0x",
-            "liquidityLayerAddress": "0x8Cd7D7C980cd72eBD16737dC3fa04469dcFcf07A",
+            "circleMessageTransmitter": "0x0000000000000000000000000000000000000000",
+            "feeRecipient": "0x0000000000000000000000000000000000000000",
+            "feeUpdater": "0x0000000000000000000000000000000000000000",
+            "liquidityLayerAddress": "0x0000000000000000000000000000000000000000",
             "permit2Address": "0x0000000000000000000000000000000000000000",
-            "traderJoeRouterAddress": "0xb4315e873dBcf96Ffd0acd8EA43f689D8c20fB30",
+            "traderJoeRouterAddress": "0x0000000000000000000000000000000000000000",
             "universalRouterAddress": "0x0000000000000000000000000000000000000000",
-            "wethAddress": "0xd00ae08403b9bbb9124bb305c09058e32c39a48c",
-            "wormholeAddress": "0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C"
+            "wethAddress": "0x0000000000000000000000000000000000000000",
+            "wormholeAddress": "0x0000000000000000000000000000000000000000"
         },
         {
-            "assistant": "0x",
+            "assistant": "0x0000000000000000000000000000000000000000",
             "chainId": 10003,
             "circleDomain": 3,
-            "circleMessageTransmitter": "0xaCF1ceeF35caAc005e15888dDb8A3515C41B4872",
-            "feeRecipient": "0x",
-            "feeUpdater": "0x",
-            "liquidityLayerAddress": "0xe0418C44F06B0b0D7D1706E01706316DBB0B210E",
-            "permit2Address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
+            "circleMessageTransmitter": "0x0000000000000000000000000000000000000000",
+            "feeRecipient": "0x0000000000000000000000000000000000000000",
+            "feeUpdater": "0x0000000000000000000000000000000000000000",
+            "liquidityLayerAddress": "0x0000000000000000000000000000000000000000",
+            "permit2Address": "0x0000000000000000000000000000000000000000",
             "traderJoeRouterAddress": "0x0000000000000000000000000000000000000000",
-            "universalRouterAddress": "0x4A7b5Da61326A6379179b40d00F57E5bbDC962c2",
-            "wethAddress": "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73",
-            "wormholeAddress": "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"
+            "universalRouterAddress": "0x0000000000000000000000000000000000000000",
+            "wethAddress": "0x0000000000000000000000000000000000000000",
+            "wormholeAddress": "0x0000000000000000000000000000000000000000"
         }
     ],
     "registrations": [
-        {
-            "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        { 
             "baseFee": 250000,
             "chainId": 6,
             "gasDropoffMargin": 1,
             "gasPrice": 250000000000,
             "gasPriceMargin": 25,
             "gasTokenPrice": 100000000,
-            "maxGasDropoff": 100000000000000000
+            "maxGasDropoff": 100000000000000000,
+            "swapLayerAddress": "0x0000000000000000000000000000000000000000000000000000000000000000"
         },
-        {
-            "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        { 
             "baseFee": 250000,
             "chainId": 10003,
             "gasDropoffMargin": 1,
             "gasPrice": 250000000000,
             "gasPriceMargin": 25,
             "gasTokenPrice": 100000000,
-            "maxGasDropoff": 100000000000000000
+            "maxGasDropoff": 100000000000000000,
+            "swapLayerAddress": "0x0000000000000000000000000000000000000000000000000000000000000000"
         }
     ]
 }

--- a/evm/cfg/evm.deployment.json
+++ b/evm/cfg/evm.deployment.json
@@ -31,12 +31,24 @@
     ],
     "registrations": [
         {
+            "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "baseFee": 250000,
             "chainId": 6,
-            "address": "0x"
+            "gasDropoffMargin": 1,
+            "gasPrice": 250000000000,
+            "gasPriceMargin": 25,
+            "gasTokenPrice": 100000000,
+            "maxGasDropoff": 100000000000000000
         },
         {
+            "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "baseFee": 250000,
             "chainId": 10003,
-            "address": "0x"
+            "gasDropoffMargin": 1,
+            "gasPrice": 250000000000,
+            "gasPriceMargin": 25,
+            "gasTokenPrice": 100000000,
+            "maxGasDropoff": 100000000000000000
         }
     ]
 }

--- a/evm/forge-scripts/ConfigureSwapLayer.s.sol
+++ b/evm/forge-scripts/ConfigureSwapLayer.s.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.24;
+
+import "forge-std/console2.sol";
+
+import "wormhole-sdk/proxy/Proxy.sol";
+import {SwapLayer} from "swap-layer/SwapLayer.sol";
+
+import {ParseSwapLayerConfig} from "./utils/ParseSLConfig.sol";
+
+import "swap-layer/assets/SwapLayerRelayingFees.sol";
+import "swap-layer/assets/SwapLayerGovernance.sol";
+
+contract ConfigureSwapLayerForTest is ParseSwapLayerConfig {
+    function createPeerRegistrationCommand(
+        SLRegistration memory config
+    ) internal returns (bytes memory) {
+        FeeParams feeParams;
+        feeParams = feeParams.baseFee(config.baseFee);
+        feeParams = feeParams.gasPrice(GasPriceLib.to(config.gasPrice));
+        feeParams = feeParams.gasPriceMargin(PercentageLib.to(config.gasPriceMargin, 0));
+        feeParams = feeParams.maxGasDropoff(GasDropoffLib.to(config.maxGasDropoff));
+        feeParams = feeParams.gasDropoffMargin(PercentageLib.to(config.gasDropoffMargin, 0));
+        feeParams = feeParams.gasTokenPrice(config.gasTokenPrice);
+
+        return abi.encodePacked(
+            GovernanceCommand.UpdatePeer,
+            config.chainId,
+            config.addr,
+            feeParams
+        );
+    }
+
+    function run() public {
+        vm.startBroadcast();
+
+        (SLRegistration[] memory config, SwapLayer swapLayer) = _parseRegistrationConfig(
+            uint16(vm.envUint("RELEASE_WORMHOLE_CHAIN_ID"))
+        );
+
+        bytes memory governanceCommands;
+        // TODO: loop through config (ignoring the deployment chainID) and encode governance commands
+        // using the createPeerRegistrationCommand function.
+
+        // NOTE: See Governance.t.sol as a reference for how to batchGovernanceCommands.
+
+        vm.stopBroadcast();
+    }
+}

--- a/evm/forge-scripts/DeploySwapLayer.s.sol
+++ b/evm/forge-scripts/DeploySwapLayer.s.sol
@@ -22,12 +22,7 @@ contract DeploySwapLayerForTest is ParseSwapLayerConfig {
                         config.traderJoeRouter
                     )
                 ),
-                abi.encodePacked(
-                    msg.sender,
-                    config.assistant,
-                    config.feeUpdater,
-                    config.feeRecipient
-                )
+                abi.encodePacked(msg.sender, config.assistant, config.feeUpdater, config.feeRecipient)
             )
         );
 
@@ -38,9 +33,8 @@ contract DeploySwapLayerForTest is ParseSwapLayerConfig {
     function run() public {
         vm.startBroadcast();
 
-        DeploymentConfig memory config = _parseAndValidateDeploymentConfig(
-            uint16(vm.envUint("RELEASE_WORMHOLE_CHAIN_ID"))
-        );
+        DeploymentConfig memory config =
+            _parseAndValidateDeploymentConfig(uint16(vm.envUint("RELEASE_WORMHOLE_CHAIN_ID")));
 
         deploy(config);
         vm.stopBroadcast();

--- a/evm/forge-scripts/DeploySwapLayer.s.sol
+++ b/evm/forge-scripts/DeploySwapLayer.s.sol
@@ -10,54 +10,39 @@ import {SwapLayer} from "swap-layer/SwapLayer.sol";
 import {ParseSwapLayerConfig} from "./utils/ParseSLConfig.sol";
 
 contract DeploySwapLayerForTest is ParseSwapLayerConfig {
-    function deploy() public {
-        // address swapLayer = address(
-        //     new Proxy(
-        //         address(
-        //             new SwapLayer(
-        //                 tokenRouter,
-        //                 permit2Contract,
-        //                 wnative,
-        //                 uniswapRouterAddress,
-        //                 traderJoeRouterAddress
-        //             )
-        //         ),
-        //         abi.encodePacked(
-        //             msg.sender,
-        //             assistant,
-        //             feeUpdater,
-        //             feeRecipient,
-        //             solChain,
-        //             solSwapLayer,
-        //             feeParams,
-        //             evmChain,
-        //             evmSwapLayer,
-        //             feeParams
-        //         )
-        //     )
-        // );
+    function deploy(DeploymentConfig memory config) public {
+        address swapLayer = address(
+            new Proxy(
+                address(
+                    new SwapLayer(
+                        config.liquidityLayer,
+                        config.permit2,
+                        config.weth,
+                        config.universalRouter,
+                        config.traderJoeRouter
+                    )
+                ),
+                abi.encodePacked(
+                    msg.sender,
+                    config.assistant,
+                    config.feeUpdater,
+                    config.feeRecipient
+                )
+            )
+        );
 
-        //console.log("Swap layer deployed at:", swapLayer);
+        console2.log("Swap layer proxy deployed at:", swapLayer);
         return;
     }
 
     function run() public {
         vm.startBroadcast();
 
-        ChainConfig[] memory config = _parseAndValidateConfigFile(6);
+        DeploymentConfig memory config = _parseAndValidateDeploymentConfig(
+            uint16(vm.envUint("RELEASE_WORMHOLE_CHAIN_ID"))
+        );
 
-        console2.log("chain id: %s", config[0].chainId);
-        console2.log("circleDomain: %s", config[0].circleDomain);
-        console2.log("wormhole: %s", config[0].wormhole);
-        console2.log("liquidityLayer: %s", config[0].liquidityLayer);
-        console2.log("universalRouter: %s", config[0].universalRouter);
-        console2.log("permit2: %s", config[0].permit2);
-        console2.log("usdc: %s", config[0].usdc);
-        console2.log("circleMessageTransmitter: %s", config[0].circleMessageTransmitter);
-        console2.log("weth: %s", config[0].weth);
-        console2.log("traderJoeRouter: %s", config[0].traderJoeRouter);
-
-        //deploy();
+        deploy(config);
         vm.stopBroadcast();
     }
 }

--- a/evm/forge-scripts/DeploySwapLayer.s.sol
+++ b/evm/forge-scripts/DeploySwapLayer.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.24;
+
+import "forge-std/console2.sol";
+
+import "wormhole-sdk/proxy/Proxy.sol";
+import {SwapLayer} from "swap-layer/SwapLayer.sol";
+
+import {ParseSwapLayerConfig} from "./utils/ParseSLConfig.sol";
+
+contract DeploySwapLayerForTest is ParseSwapLayerConfig {
+    function deploy() public {
+        // address swapLayer = address(
+        //     new Proxy(
+        //         address(
+        //             new SwapLayer(
+        //                 tokenRouter,
+        //                 permit2Contract,
+        //                 wnative,
+        //                 uniswapRouterAddress,
+        //                 traderJoeRouterAddress
+        //             )
+        //         ),
+        //         abi.encodePacked(
+        //             msg.sender,
+        //             assistant,
+        //             feeUpdater,
+        //             feeRecipient,
+        //             solChain,
+        //             solSwapLayer,
+        //             feeParams,
+        //             evmChain,
+        //             evmSwapLayer,
+        //             feeParams
+        //         )
+        //     )
+        // );
+
+        //console.log("Swap layer deployed at:", swapLayer);
+        return;
+    }
+
+    function run() public {
+        vm.startBroadcast();
+
+        ChainConfig[] memory config = _parseAndValidateConfigFile(6);
+
+        console2.log("chain id: %s", config[0].chainId);
+        console2.log("circleDomain: %s", config[0].circleDomain);
+        console2.log("wormhole: %s", config[0].wormhole);
+        console2.log("liquidityLayer: %s", config[0].liquidityLayer);
+        console2.log("universalRouter: %s", config[0].universalRouter);
+        console2.log("permit2: %s", config[0].permit2);
+        console2.log("usdc: %s", config[0].usdc);
+        console2.log("circleMessageTransmitter: %s", config[0].circleMessageTransmitter);
+        console2.log("weth: %s", config[0].weth);
+        console2.log("traderJoeRouter: %s", config[0].traderJoeRouter);
+
+        //deploy();
+        vm.stopBroadcast();
+    }
+}

--- a/evm/forge-scripts/ValidateSwapLayer.s.sol
+++ b/evm/forge-scripts/ValidateSwapLayer.s.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.24;
+
+import "forge-std/console2.sol";
+
+import "wormhole-sdk/proxy/Proxy.sol";
+import "wormhole-sdk/libraries/BytesParsing.sol";
+import {SwapLayer} from "swap-layer/SwapLayer.sol";
+
+import {ParseSwapLayerConfig} from "./utils/ParseSLConfig.sol";
+
+import "swap-layer/assets/SwapLayerRelayingFees.sol";
+import "swap-layer/assets/SwapLayerGovernance.sol";
+import "swap-layer/assets/SwapLayerQuery.sol";
+
+contract ValidateSwapLayerForTest is ParseSwapLayerConfig {
+    using BytesParsing for bytes;
+
+    function validatePeers(uint16 wormholeChainId, SwapLayer swapLayer, SLRegistration[] memory registrations)
+        internal
+        view
+    {
+        // Loop through each registration and validate the peer.
+        for (uint256 i = 0; i < registrations.length; i++) {
+            SLRegistration memory registration = registrations[i];
+            if (registration.chainId == wormholeChainId) {
+                // Skip self registration.
+                continue;
+            }
+
+            bytes memory getRes = swapLayer.batchQueries(abi.encodePacked(QueryType.Peer, registration.chainId));
+            (bytes32 peer,) = getRes.asBytes32Unchecked(0);
+            require(peer == registration.swapLayer, "Peer mismatch");
+        }
+    }
+
+    function validateFeeParams(uint16 wormholeChainId, SwapLayer swapLayer, SLRegistration[] memory registrations)
+        internal
+        view
+    {
+        // Loop through each registration and validate the fee params.
+        for (uint256 i = 0; i < registrations.length; i++) {
+            SLRegistration memory registration = registrations[i];
+            if (registration.chainId == wormholeChainId) {
+                // Skip self registration.
+                continue;
+            }
+
+            bytes memory getRes = swapLayer.batchQueries(abi.encodePacked(QueryType.FeeParams, registration.chainId));
+            (uint256 queriedFeeParams,) = getRes.asUint256Unchecked(0);
+
+            // Parse the fee params.
+            FeeParams feeParams;
+            feeParams = feeParams.baseFee(registration.baseFee);
+            feeParams = feeParams.gasPrice(GasPriceLib.to(registration.gasPrice));
+            feeParams = feeParams.gasPriceMargin(PercentageLib.to(registration.gasPriceMargin, 0));
+            feeParams = feeParams.maxGasDropoff(GasDropoffLib.to(registration.maxGasDropoff));
+            feeParams = feeParams.gasDropoffMargin(PercentageLib.to(registration.gasDropoffMargin, 0));
+            feeParams = feeParams.gasTokenPrice(registration.gasTokenPrice);
+
+            require(FeeParams.unwrap(feeParams) == queriedFeeParams, "Fee params mismatch");
+        }
+    }
+
+    function validateDeploymentAndConfiguration(
+        uint16 wormholeChainId,
+        SwapLayer swapLayer,
+        DeploymentConfig memory deployConfig,
+        SLRegistration[] memory registrations
+    ) internal view {
+        bytes memory getRes = swapLayer.batchQueries(
+            abi.encodePacked(
+                QueryType.Owner,
+                QueryType.PendingOwner,
+                QueryType.FeeRecipient,
+                QueryType.FeeUpdater,
+                QueryType.Assistant
+            )
+        );
+        (address owner,) = getRes.asAddressUnchecked(0);
+        (address pendingOwner,) = getRes.asAddressUnchecked(20);
+        (address feeRecipient,) = getRes.asAddressUnchecked(40);
+        (address feeUpdater,) = getRes.asAddressUnchecked(60);
+        (address assistant,) = getRes.asAddressUnchecked(80);
+
+        require(owner == msg.sender, "Owner mismatch");
+        require(pendingOwner == address(0), "Pending owner mismatch");
+        require(feeRecipient == deployConfig.feeRecipient, "Fee recipient mismatch");
+        require(feeUpdater == deployConfig.feeUpdater, "Fee updater mismatch");
+        require(assistant == deployConfig.assistant, "Assistant mismatch");
+
+        validatePeers(wormholeChainId, swapLayer, registrations);
+
+        validateFeeParams(wormholeChainId, swapLayer, registrations);
+
+        getRes = swapLayer.batchQueries(
+            abi.encodePacked(
+                QueryType.Immutable,
+                ImmutableType.Wormhole,
+                QueryType.Immutable,
+                ImmutableType.WrappedNative,
+                QueryType.Immutable,
+                ImmutableType.Permit2,
+                QueryType.Immutable,
+                ImmutableType.UniswapRouter,
+                QueryType.Immutable,
+                ImmutableType.TraderJoeRouter,
+                QueryType.Immutable,
+                ImmutableType.LiquidityLayer
+            )
+        );
+
+        (address wormhole,) = getRes.asAddressUnchecked(0);
+        (address weth,) = getRes.asAddressUnchecked(20);
+        (address permit2,) = getRes.asAddressUnchecked(40);
+        (address universalRouter,) = getRes.asAddressUnchecked(60);
+        (address traderJoe,) = getRes.asAddressUnchecked(80);
+        (address liquidity,) = getRes.asAddressUnchecked(100);
+
+        require(wormhole == deployConfig.wormhole, "Wormhole mismatch");
+        require(weth == deployConfig.weth, "WETH mismatch");
+        require(permit2 == deployConfig.permit2, "Permit2 mismatch");
+        require(universalRouter == deployConfig.universalRouter, "Uniswap router mismatch");
+        require(traderJoe == deployConfig.traderJoeRouter, "Trader Joe router mismatch");
+        require(liquidity == deployConfig.liquidityLayer, "Liquidity layer mismatch");
+    }
+
+    function run() public {
+        vm.startBroadcast();
+
+        // Wormhole chain ID that we are configuring.
+        uint16 thisChainId = uint16(vm.envUint("RELEASE_WORMHOLE_CHAIN_ID"));
+
+        DeploymentConfig memory deployConfig = _parseAndValidateDeploymentConfig(thisChainId);
+        (SLRegistration[] memory registrations, SwapLayer swapLayer) = _parseRegistrationConfig(thisChainId);
+
+        validateDeploymentAndConfiguration(thisChainId, swapLayer, deployConfig, registrations);
+
+        vm.stopBroadcast();
+    }
+}

--- a/evm/forge-scripts/utils/ParseSLConfig.sol
+++ b/evm/forge-scripts/utils/ParseSLConfig.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity >=0.8.8 <0.9.0;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+
+import {ISwapLayer} from "swap-layer/ISwapLayer.sol";
+
+contract ParseSwapLayerConfig is Script {
+    using stdJson for string;
+
+    // NOTE: Forge expects any struct to be defined in alphabetical order if being used
+    // to parse JSON.
+    struct ChainConfig {
+        uint16 chainId;
+        uint32 circleDomain;
+        address wormhole;
+        address liquidityLayer;
+        address universalRouter;
+        address permit2;
+        address usdc;
+        address circleMessageTransmitter;
+        address weth;
+        address traderJoeRouter;
+    }
+
+    mapping(uint16 => bool) duplicateChainIds;
+
+    function toUniversalAddress(
+        address evmAddr
+    ) internal pure returns (bytes32 converted) {
+        assembly ("memory-safe") {
+            converted := and(0xffffffffffffffffffffffffffffffffffffffff, evmAddr)
+        }
+    }
+
+    function fromUniversalAddress(
+        bytes32 universalAddr
+    ) internal pure returns (address converted) {
+        require(bytes12(universalAddr) == 0, "Address overflow");
+
+        assembly ("memory-safe") {
+            converted := universalAddr
+        }
+    }
+
+    function _parseAndValidateConfigFile(
+        uint16 wormholeChainId
+    )
+        internal
+        returns (
+            ChainConfig[] memory config
+        )
+    {
+        string memory root = vm.projectRoot();
+        string memory path = string.concat(root, "/cfg/evm.deployment.json");
+        string memory json = vm.readFile(path);
+        bytes memory contracts = json.parseRaw(".contracts");
+
+        // Decode the json into ChainConfig array.
+        config = abi.decode(contracts, (ChainConfig[]));
+
+        // Validate values and set the contract addresses for this chain.
+        for (uint256 i = 0; i < config.length; i++) {
+            require(config[i].chainId != 0, "Invalid chain ID");
+
+            // Make sure we don't configure the same chain twice.
+            require(!duplicateChainIds[config[i].chainId], "Duplicate chain ID");
+            duplicateChainIds[config[i].chainId] = true;
+        }
+
+        require(duplicateChainIds[wormholeChainId], "Wormhole chain ID not found");
+    }
+}

--- a/evm/forge-scripts/utils/ParseSLConfig.sol
+++ b/evm/forge-scripts/utils/ParseSLConfig.sol
@@ -27,7 +27,6 @@ contract ParseSwapLayerConfig is Script {
     }
 
     struct SLRegistration {
-        bytes32 addr;
         uint32 baseFee;
         uint16 chainId;
         uint256 gasDropoffMargin;
@@ -35,13 +34,12 @@ contract ParseSwapLayerConfig is Script {
         uint256 gasPriceMargin;
         uint64 gasTokenPrice;
         uint256 maxGasDropoff;
+        bytes32 swapLayer;
     }
 
     mapping(uint16 => bool) duplicateChainIds;
 
-    function fromUniversalAddress(
-        bytes32 universalAddr
-    ) internal pure returns (address converted) {
+    function fromUniversalAddress(bytes32 universalAddr) internal pure returns (address converted) {
         require(bytes12(universalAddr) == 0, "Address overflow");
 
         assembly ("memory-safe") {
@@ -49,14 +47,9 @@ contract ParseSwapLayerConfig is Script {
         }
     }
 
-    function _parseRegistrationConfig(
-        uint16 wormholeChainId
-    )
+    function _parseRegistrationConfig(uint16 wormholeChainId)
         internal
-        returns (
-            SLRegistration[] memory configs,
-            SwapLayer swapLayer
-        )
+        returns (SLRegistration[] memory configs, SwapLayer swapLayer)
     {
         require(wormholeChainId > 0, "Invalid chain id");
 
@@ -75,18 +68,15 @@ contract ParseSwapLayerConfig is Script {
 
             // Set the contract addresses for this chain.
             if (targetConfig.chainId == wormholeChainId) {
-                swapLayer = SwapLayer(payable(fromUniversalAddress(targetConfig.addr)));
+                swapLayer = SwapLayer(payable(fromUniversalAddress(targetConfig.swapLayer)));
             }
         }
     }
 
-    function _parseAndValidateDeploymentConfig(
-        uint16 wormholeChainId
-    )
+    function _parseAndValidateDeploymentConfig(uint16 wormholeChainId)
         internal
-        returns (
-            DeploymentConfig memory config
-        )
+        view
+        returns (DeploymentConfig memory)
     {
         require(wormholeChainId > 0, "Invalid chain id");
 

--- a/evm/forge-scripts/utils/ParseSLConfig.sol
+++ b/evm/forge-scripts/utils/ParseSLConfig.sol
@@ -14,14 +14,14 @@ contract ParseSwapLayerConfig is Script {
     struct ChainConfig {
         uint16 chainId;
         uint32 circleDomain;
-        address wormhole;
-        address liquidityLayer;
-        address universalRouter;
-        address permit2;
-        address usdc;
         address circleMessageTransmitter;
-        address weth;
+        address liquidityLayer;
+        address permit2;
         address traderJoeRouter;
+        address universalRouter;
+        address usdc;
+        address weth;
+        address wormhole;
     }
 
     mapping(uint16 => bool) duplicateChainIds;

--- a/evm/foundry.toml
+++ b/evm/foundry.toml
@@ -4,6 +4,7 @@ evm_version = "paris" # prevent use of PUSH0 opcode until it is widely supported
 optimizer = true
 via_ir = true
 extra_output = ["metadata", "storageLayout", "evm.deployedBytecode.immutableReferences"]
+fs_permissions = [{access = "read", path = "./cfg/"}]
 
 libs = [
     "lib",

--- a/evm/sh/deploy.sh
+++ b/evm/sh/deploy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-while getopts ":c:r:k:" opt; do
+while getopts ":c:r:k:a:" opt; do
   case $opt in
     c) chain="$OPTARG"
     ;;
@@ -8,11 +7,12 @@ while getopts ":c:r:k:" opt; do
     ;;
     k) private_key="$OPTARG"
     ;;
+    a) action="$OPTARG"
+    ;;
     \?) echo "Invalid option -$OPTARG" >&2
     exit 1
     ;;
   esac
-
   case $OPTARG in
     -*) echo "Option $opt needs a valid argument" >&2
     exit 1
@@ -20,32 +20,46 @@ while getopts ":c:r:k:" opt; do
   esac
 done
 
-if [ -z ${rpc+x} ];
-then
+# Validate required parameters
+if [ -z ${rpc+x} ]; then
     echo "rpc (-r) is unset" >&2
     exit 1
 fi
-
-if [ -z ${chain+x} ];
-then
+if [ -z ${chain+x} ]; then
     echo "chain (-c) is unset" >&2
     exit 1
 fi
-
-if [ -z ${private_key+x} ];
-then
+if [ -z ${private_key+x} ]; then
     echo "private key (-k) is unset" >&2
+    exit 1
+fi
+# Set default action to deploy if not specified
+if [ -z ${action+x} ]; then
+    action="deploy"
+fi
+
+# Validate action parameter
+# Validate action if specified
+if [ "$action" != "deploy" ] && [ "$action" != "configure" ] && [ "$action" != "validate" ]; then
+    echo "action (-a) if specified must be one of: 'deploy', 'configure', or 'validate'" >&2
     exit 1
 fi
 
 set -euo pipefail
-
 ROOT=$(dirname $0)
 FORGE_SCRIPTS=$ROOT/../forge-scripts
-
 export RELEASE_WORMHOLE_CHAIN_ID=$chain
 
-forge script $FORGE_SCRIPTS/DeploySwapLayer.s.sol \
+# Determine which script to run based on action
+if [ "$action" = "deploy" ]; then
+    SCRIPT_NAME="DeploySwapLayer.s.sol"
+elif [ "$action" = "configure" ]; then
+    SCRIPT_NAME="ConfigureSwapLayer.s.sol"
+else
+    SCRIPT_NAME="ValidateSwapLayer.s.sol"
+fi
+
+forge script $FORGE_SCRIPTS/$SCRIPT_NAME \
     --rpc-url $rpc \
     --broadcast \
     --private-key $private_key \

--- a/evm/sh/deploy.sh
+++ b/evm/sh/deploy.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+while getopts ":c:r:k:" opt; do
+  case $opt in
+    c) chain="$OPTARG"
+    ;;
+    r) rpc="$OPTARG"
+    ;;
+    k) private_key="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    exit 1
+    ;;
+  esac
+
+  case $OPTARG in
+    -*) echo "Option $opt needs a valid argument" >&2
+    exit 1
+    ;;
+  esac
+done
+
+if [ -z ${rpc+x} ];
+then
+    echo "rpc (-r) is unset" >&2
+    exit 1
+fi
+
+if [ -z ${chain+x} ];
+then
+    echo "chain (-c) is unset" >&2
+    exit 1
+fi
+
+if [ -z ${private_key+x} ];
+then
+    echo "private key (-k) is unset" >&2
+    exit 1
+fi
+
+set -euo pipefail
+
+ROOT=$(dirname $0)
+FORGE_SCRIPTS=$ROOT/../forge-scripts
+
+export RELEASE_WORMHOLE_CHAIN_ID=$chain
+
+forge script $FORGE_SCRIPTS/DeploySwapLayer.s.sol \
+    --rpc-url $rpc \
+    --broadcast \
+    --private-key $private_key \
+    --slow \
+    --skip test


### PR DESCRIPTION
The TS scripts are having an existential crisis, so we've added Forge/Foundry as a backup deployment path. Now integrators can pick their preferred flavoring of debug messages - because everyone deserves options when diving into deployment chaos.